### PR TITLE
General code quality fix-3

### DIFF
--- a/library/src/main/java/com/duowan/mobile/netroid/ExecutorDelivery.java
+++ b/library/src/main/java/com/duowan/mobile/netroid/ExecutorDelivery.java
@@ -176,7 +176,7 @@ public class ExecutorDelivery implements Delivery {
             if (mResponse.isSuccess()) {
                 mRequest.deliverSuccess(mResponse.result);
             } else {
-                mRequest.deliverError(mResponse.error);
+                mRequest.deliverError(mResponse.errorDetail);
             }
 
             // If this is an intermediate response, add a marker, otherwise we're done

--- a/library/src/main/java/com/duowan/mobile/netroid/Response.java
+++ b/library/src/main/java/com/duowan/mobile/netroid/Response.java
@@ -44,7 +44,7 @@ public class Response<T> {
     public final DiskCache.Entry cacheEntry;
 
     /** Detailed error information if <code>errorCode != OK</code>. */
-    public final NetroidError error;
+    public final NetroidError errorDetail;
 
     /** True if this response was a soft-expired one and a second one MAY be coming. */
     public boolean intermediate = false;
@@ -53,18 +53,18 @@ public class Response<T> {
      * Returns whether this response is considered successful.
      */
     public boolean isSuccess() {
-        return error == null;
+        return errorDetail == null;
     }
 
     private Response(T result, DiskCache.Entry cacheEntry) {
         this.result = result;
         this.cacheEntry = cacheEntry;
-        this.error = null;
+        this.errorDetail = null;
     }
 
     private Response(NetroidError error) {
         this.result = null;
         this.cacheEntry = null;
-        this.error = error;
+        this.errorDetail = error;
     }
 }

--- a/library/src/main/java/com/duowan/mobile/netroid/cache/LruCache.java
+++ b/library/src/main/java/com/duowan/mobile/netroid/cache/LruCache.java
@@ -26,8 +26,10 @@ import java.util.Map;
  * framework's implementation. See the framework SDK documentation for a class
  * overview.
  */
-public class LruCache<K, V> {
-	private final LinkedHashMap<K, V> map;
+public class LruCache<K, V> {	
+
+    private final LinkedHashMap<K, V> map;
+    private static final int DEF_ENTRY_SIZE = 1;
 
 	/** Size of this cache in units. Not necessarily the number of elements. */
 	private int size;
@@ -242,7 +244,7 @@ public class LruCache<K, V> {
 	 * <p>An entry's size must not change while it is in the cache.
 	 */
 	protected int sizeOf(K key, V value) {
-		return 1;
+		return DEF_ENTRY_SIZE;
 	}
 
 	/**

--- a/library/src/main/java/com/duowan/mobile/netroid/stack/HttpClientStack.java
+++ b/library/src/main/java/com/duowan/mobile/netroid/stack/HttpClientStack.java
@@ -17,9 +17,11 @@
 package com.duowan.mobile.netroid.stack;
 
 import android.net.http.AndroidHttpClient;
+
 import com.duowan.mobile.netroid.AuthFailureError;
 import com.duowan.mobile.netroid.Request;
 import com.duowan.mobile.netroid.Request.Method;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -36,6 +38,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * An HttpStack that performs request over an {@link HttpClient}.
@@ -52,16 +55,16 @@ public class HttpClientStack implements HttpStack {
 	}
 
     private static void addHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
-        for (String key : headers.keySet()) {
-            httpRequest.setHeader(key, headers.get(key));
+        for (Entry<String, String> header : headers.entrySet()) {
+            httpRequest.setHeader(header.getKey(), header.getValue());
         }
     }
 
     @SuppressWarnings("unused")
     private static List<NameValuePair> getPostParameterPairs(Map<String, String> postParams) {
         List<NameValuePair> result = new ArrayList<NameValuePair>(postParams.size());
-        for (String key : postParams.keySet()) {
-            result.add(new BasicNameValuePair(key, postParams.get(key)));
+        for (Entry<String, String> param : postParams.entrySet()) {
+            result.add(new BasicNameValuePair(param.getKey(), param.getValue()));
         }
         return result;
     }

--- a/library/src/main/java/com/duowan/mobile/netroid/stack/HurlStack.java
+++ b/library/src/main/java/com/duowan/mobile/netroid/stack/HurlStack.java
@@ -17,9 +17,11 @@
 package com.duowan.mobile.netroid.stack;
 
 import android.text.TextUtils;
+
 import com.duowan.mobile.netroid.AuthFailureError;
 import com.duowan.mobile.netroid.Request;
 import com.duowan.mobile.netroid.Request.Method;
+
 import org.apache.http.*;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHeader;
@@ -29,6 +31,7 @@ import org.apache.http.protocol.HTTP;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,8 +71,8 @@ public class HurlStack implements HttpStack {
 
 		URL parsedUrl = new URL(request.getUrl());
 		HttpURLConnection connection = openConnection(parsedUrl, request);
-		for (String headerName : map.keySet()) {
-			connection.addRequestProperty(headerName, map.get(headerName));
+		for (Entry<String, String> header : map.entrySet()) {
+			connection.addRequestProperty(header.getKey(), header.getValue());
 		}
 
 		setConnectionParametersForRequest(connection, request);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S1845 - Methods and field names should not be the same or differ only by capitalization.
squid:S3400 - Methods should not return constants
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1845
https://dev.eclipse.org/sonar/rules/show/squid:S3400

Please let me know if you have any questions.

Faisal Hameed