### PR TITLE
Code quality fix - Modifiers should be declared in the correct order.

### DIFF
--- a/library/src/main/java/com/vincestyling/netroid/cache/LruCache.java
+++ b/library/src/main/java/com/vincestyling/netroid/cache/LruCache.java
@@ -289,7 +289,7 @@ public class LruCache<K, V> {
      * of entries in the cache. For all other caches, this returns the sum of
      * the sizes of the entries in this cache.
      */
-    public synchronized final int size() {
+    public final synchronized int size() {
         return size;
     }
 
@@ -298,7 +298,7 @@ public class LruCache<K, V> {
      * number of entries in the cache. For all other caches, this returns the
      * maximum sum of the sizes of the entries in this cache.
      */
-    public synchronized final int maxSize() {
+    public final synchronized int maxSize() {
         return maxSize;
     }
 
@@ -306,7 +306,7 @@ public class LruCache<K, V> {
      * Returns the number of times {@link #get} returned a value that was
      * already present in the cache.
      */
-    public synchronized final int hitCount() {
+    public final synchronized int hitCount() {
         return hitCount;
     }
 
@@ -314,28 +314,28 @@ public class LruCache<K, V> {
      * Returns the number of times {@link #get} returned null or required a new
      * value to be created.
      */
-    public synchronized final int missCount() {
+    public final synchronized int missCount() {
         return missCount;
     }
 
     /**
      * Returns the number of times {@link #create(Object)} returned a value.
      */
-    public synchronized final int createCount() {
+    public final synchronized int createCount() {
         return createCount;
     }
 
     /**
      * Returns the number of times {@link #put} was called.
      */
-    public synchronized final int putCount() {
+    public final synchronized int putCount() {
         return putCount;
     }
 
     /**
      * Returns the number of values that have been evicted.
      */
-    public synchronized final int evictionCount() {
+    public final synchronized int evictionCount() {
         return evictionCount;
     }
 
@@ -343,12 +343,12 @@ public class LruCache<K, V> {
      * Returns a copy of the current contents of the cache, ordered from least
      * recently accessed to most recently accessed.
      */
-    public synchronized final Map<K, V> snapshot() {
+    public final synchronized Map<K, V> snapshot() {
         return new LinkedHashMap<K, V>(map);
     }
 
     @Override
-    public synchronized final String toString() {
+    public final synchronized String toString() {
         int accesses = hitCount + missCount;
         int hitPercent = accesses != 0 ? (100 * hitCount / accesses) : 0;
         return String.format("LruCache[maxSize=%d,hits=%d,misses=%d,hitRate=%d%%]",

--- a/library/src/main/java/com/vincestyling/netroid/request/JsonRequest.java
+++ b/library/src/main/java/com/vincestyling/netroid/request/JsonRequest.java
@@ -45,7 +45,7 @@ public abstract class JsonRequest<T> extends Request<T> {
     }
 
     @Override
-    abstract protected Response<T> parseNetworkResponse(NetworkResponse response);
+    protected abstract Response<T> parseNetworkResponse(NetworkResponse response);
 
     @Override
     public String getBodyContentType() {

--- a/library/src/main/java/com/vincestyling/netroid/stack/HttpClientStack.java
+++ b/library/src/main/java/com/vincestyling/netroid/stack/HttpClientStack.java
@@ -135,7 +135,7 @@ public class HttpClientStack implements HttpStack {
      * The HttpPatch class does not exist in the Android framework, so this has been defined here.
      */
     public static final class HttpPatch extends HttpEntityEnclosingRequestBase {
-        public final static String METHOD_NAME = "PATCH";
+        public static final String METHOD_NAME = "PATCH";
 
         public HttpPatch() {
             super();

--- a/sample/src/main/java/com/vincestyling/netroid/sample/FileDownloadActivity.java
+++ b/sample/src/main/java/com/vincestyling/netroid/sample/FileDownloadActivity.java
@@ -27,7 +27,7 @@ import java.util.LinkedList;
  */
 public class FileDownloadActivity extends BaseActivity implements
         View.OnClickListener, AdapterView.OnItemClickListener, AdapterView.OnItemLongClickListener {
-    public final static DecimalFormat DECIMAL_POINT = new DecimalFormat("0.0");
+    public static final DecimalFormat DECIMAL_POINT = new DecimalFormat("0.0");
 
     private LinkedList<DownloadTask> mTaskList;
     private LinkedList<DownloadTask> mDownloadList;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.

Faisal Hameed
