### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/library/src/main/java/com/vincestyling/netroid/NetroidLog.java
+++ b/library/src/main/java/com/vincestyling/netroid/NetroidLog.java
@@ -27,13 +27,14 @@ import java.util.Locale;
  */
 public class NetroidLog {
 
-    private NetroidLog() {
-        /* cannot be instantiated */
-    }
 
     public static String TAG = "Netroid";
 
     public static boolean DEBUG = Log.isLoggable(TAG, Log.VERBOSE);
+
+    private NetroidLog() {
+        /* cannot be instantiated */
+    }
 
     /**
      * Customize the log tag for your application, so that other apps

--- a/library/src/main/java/com/vincestyling/netroid/NetworkResponse.java
+++ b/library/src/main/java/com/vincestyling/netroid/NetworkResponse.java
@@ -21,6 +21,22 @@ import org.apache.http.HttpStatus;
  * Data and headers returned from {@link Network#performRequest(Request)}.
  */
 public class NetworkResponse {
+
+    /**
+     * The HTTP status code.
+     */
+    public final int statusCode;
+
+    /**
+     * Raw data from this response.
+     */
+    public final byte[] data;
+
+    /**
+     * Charset from this response.
+     */
+    public final String charset;
+
     /**
      * Creates a new network response.
      *
@@ -42,18 +58,4 @@ public class NetworkResponse {
         this(HttpStatus.SC_OK, data, charset);
     }
 
-    /**
-     * The HTTP status code.
-     */
-    public final int statusCode;
-
-    /**
-     * Raw data from this response.
-     */
-    public final byte[] data;
-
-    /**
-     * Charset from this response.
-     */
-    public final String charset;
 }

--- a/library/src/main/java/com/vincestyling/netroid/Request.java
+++ b/library/src/main/java/com/vincestyling/netroid/Request.java
@@ -132,6 +132,14 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      */
     private Object mTag;
 
+
+    /**
+     * Indicates DeliverPreExecute operation is done or not,
+     * because the {@link CacheDispatcher} and {@link NetworkDispatcher}
+     * both will call this deliver, and we must ensure just invoke once.
+     */
+    private boolean mIsDeliverPreExecute;
+
     /**
      * Creates a new request with the given method (one of the values from {@link Method}),
      * URL, and error listener.  Note that the normal response listener is not provided here as
@@ -597,13 +605,6 @@ public abstract class Request<T> implements Comparable<Request<T>> {
             mListener.onCancel();
         }
     }
-
-    /**
-     * Indicates DeliverPreExecute operation is done or not,
-     * because the {@link CacheDispatcher} and {@link NetworkDispatcher}
-     * both will call this deliver, and we must ensure just invoke once.
-     */
-    private boolean mIsDeliverPreExecute;
 
     /**
      * Delivers request is handling to the Listener.

--- a/library/src/main/java/com/vincestyling/netroid/Response.java
+++ b/library/src/main/java/com/vincestyling/netroid/Response.java
@@ -24,20 +24,6 @@ import com.vincestyling.netroid.cache.DiskCache;
  */
 public class Response<T> {
 
-    /**
-     * Returns a successful response containing the parsed result.
-     */
-    public static <T> Response<T> success(T result, NetworkResponse response) {
-        return new Response<>(result, response);
-    }
-
-    /**
-     * Returns a failed response containing the given error code and an optional
-     * localized message displayed to the user.
-     */
-    public static <T> Response<T> error(NetroidError error) {
-        return new Response<>(error);
-    }
 
     /**
      * Parsed response, or null in the case of error.
@@ -59,12 +45,6 @@ public class Response<T> {
      */
     public boolean intermediate = false;
 
-    /**
-     * Returns whether this response is considered successful.
-     */
-    public boolean isSuccess() {
-        return errorDetail == null;
-    }
 
     private Response(T result, NetworkResponse response) {
         this.result = result;
@@ -77,4 +57,27 @@ public class Response<T> {
         this.cacheEntry = null;
         this.errorDetail = error;
     }
+
+    /**
+     * Returns a successful response containing the parsed result.
+     */
+    public static <T> Response<T> success(T result, NetworkResponse response) {
+        return new Response<>(result, response);
+    }
+
+    /**
+     * Returns a failed response containing the given error code and an optional
+     * localized message displayed to the user.
+     */
+    public static <T> Response<T> error(NetroidError error) {
+        return new Response<>(error);
+    }
+
+    /**
+     * Returns whether this response is considered successful.
+     */
+    public boolean isSuccess() {
+        return errorDetail == null;
+    }
+
 }

--- a/library/src/main/java/com/vincestyling/netroid/cache/DiskCache.java
+++ b/library/src/main/java/com/vincestyling/netroid/cache/DiskCache.java
@@ -452,13 +452,6 @@ public class DiskCache {
      * Data and metadata for an entry returned by the cache.
      */
     public static class Entry {
-        public Entry() {
-        }
-
-        public Entry(byte[] data, String charset) {
-            this.data = data;
-            this.charset = charset;
-        }
 
         /**
          * The data returned from cache.
@@ -474,6 +467,14 @@ public class DiskCache {
          * Charset for cache entry, retrieve by the http header.
          */
         private String charset;
+
+        public Entry() {
+        }
+
+        public Entry(byte[] data, String charset) {
+            this.data = data;
+            this.charset = charset;
+        }
 
         /**
          * True if the entry is expired.

--- a/library/src/main/java/com/vincestyling/netroid/toolbox/ByteArrayPool.java
+++ b/library/src/main/java/com/vincestyling/netroid/toolbox/ByteArrayPool.java
@@ -65,6 +65,11 @@ public class ByteArrayPool {
     private final int mSizeLimit;
 
     /**
+     * Singleton for this class.
+     */
+    private static ByteArrayPool mPool;
+
+    /**
      * Compares buffers by size
      */
     protected static final Comparator<byte[]> BUF_COMPARATOR = new Comparator<byte[]>() {
@@ -81,10 +86,6 @@ public class ByteArrayPool {
         mSizeLimit = sizeLimit;
     }
 
-    /**
-     * Singleton for this class.
-     */
-    private static ByteArrayPool mPool;
 
     /**
      * Get the singleton instance.

--- a/sample/src/main/java/com/vincestyling/netroid/sample/FileDownloadActivity.java
+++ b/sample/src/main/java/com/vincestyling/netroid/sample/FileDownloadActivity.java
@@ -243,6 +243,11 @@ public class FileDownloadActivity extends BaseActivity implements
         long fileSize;
         long downloadedSize;
 
+        private DownloadTask(String storeFileName, String url) {
+            this.storeFileName = storeFileName;
+            this.url = url;
+        }
+
         private void onProgressChange(long fileSize, long downloadedSize) {
             this.fileSize = fileSize;
             this.downloadedSize = downloadedSize;
@@ -276,9 +281,5 @@ public class FileDownloadActivity extends BaseActivity implements
             txvFileSize.setText(Formatter.formatFileSize(FileDownloadActivity.this, fileSize));
         }
 
-        private DownloadTask(String storeFileName, String url) {
-            this.storeFileName = storeFileName;
-            this.url = url;
-        }
     }
 }

--- a/sample/src/main/java/com/vincestyling/netroid/sample/GridViewActivity.java
+++ b/sample/src/main/java/com/vincestyling/netroid/sample/GridViewActivity.java
@@ -23,6 +23,8 @@ public class GridViewActivity extends BaseActivity {
     private BaseAdapter mAdapter;
     private List<Book> bookList;
 
+    private Toast mToast;
+
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_gridview_p0);
@@ -133,8 +135,6 @@ public class GridViewActivity extends BaseActivity {
             }
         });
     }
-
-    private Toast mToast;
 
     private void showToast(CharSequence msg) {
         if (mToast != null) mToast.cancel();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed
