### PR TITLE
Code quality fix - Exception classes should be immutable. 

### DIFF
--- a/library/src/main/java/com/vincestyling/netroid/AuthFailureError.java
+++ b/library/src/main/java/com/vincestyling/netroid/AuthFailureError.java
@@ -24,9 +24,10 @@ public class AuthFailureError extends NetroidError {
     /**
      * An intent that can be used to resolve this exception. (Brings up the password dialog.)
      */
-    private Intent mResolutionIntent;
+    private final Intent mResolutionIntent;
 
     public AuthFailureError() {
+        mResolutionIntent = null;
     }
 
     public AuthFailureError(Intent intent) {
@@ -35,14 +36,17 @@ public class AuthFailureError extends NetroidError {
 
     public AuthFailureError(NetworkResponse response) {
         super(response);
+        mResolutionIntent = null;
     }
 
     public AuthFailureError(String message) {
         super(message);
+        mResolutionIntent = null;
     }
 
     public AuthFailureError(String message, Exception reason) {
         super(message, reason);
+        mResolutionIntent = null;
     }
 
     public Intent getResolutionIntent() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1165 - Exception classes should be immutable. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1165

Please let me know if you have any questions.

Faisal Hameed
