### PR TITLE
Code quality fix - "Object.finalize()" should remain protected (versus public) when overriding. 

### DIFF
--- a/library/src/main/java/com/vincestyling/netroid/toolbox/PoolingByteArrayOutputStream.java
+++ b/library/src/main/java/com/vincestyling/netroid/toolbox/PoolingByteArrayOutputStream.java
@@ -60,7 +60,7 @@ public class PoolingByteArrayOutputStream extends ByteArrayOutputStream {
     }
 
     @Override
-    public void finalize() {
+    protected void finalize() {
         mPool.returnBuf(buf);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1174 - "Object.finalize()" should remain protected (versus public) when overriding. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1174

Please let me know if you have any questions.

Faisal Hameed
